### PR TITLE
Update Ember version options: 4-minor ranges to 3-minor + named LTS

### DIFF
--- a/app/components/section-work.hbs
+++ b/app/components/section-work.hbs
@@ -320,13 +320,20 @@
                 <option value="blank">--please select one--</option>
                 <option value="1.x">1.x</option>
                 <option value="2.x">2.x</option>
-                <option value="3.0 - 3.4">3.0 - 3.4</option>
-                <option value="3.5 - 3.8">3.5 - 3.8</option>
-                <option value="3.9 - 3.12">3.9 - 3.12</option>
-                <option value="3.13 - 3.16">3.13 - 3.16</option>
-                <option value="3.17 - 3.20">3.17 - 3.20</option>
-                <option value="3.21 - 3.24">3.21 - 3.24</option>
-                <option value="3.25 - 3.28">3.25 - 3.28</option>
+                <option value="3.0 - 3.3">3.0 - 3.3</option>
+                <option value="3.4 LTS">3.4 LTS</option>
+                <option value="3.5 - 3.7">3.5 - 3.7</option>
+                <option value="3.8 LTS">3.8 LTS</option>
+                <option value="3.9 - 3.11">3.9 - 3.11</option>
+                <option value="3.12 LTS">3.12 LTS</option>
+                <option value="3.13 - 3.15">3.13 - 3.15</option>
+                <option value="3.16 LTS">3.16 LTS</option>
+                <option value="3.17 - 3.19">3.17 - 3.19</option>
+                <option value="3.20 LTS">3.20 LTS</option>
+                <option value="3.21 - 3.23">3.21 - 3.23</option>
+                <option value="3.24 LTS">3.24 LTS</option>
+                <option value="3.25 - 3.27">3.25 - 3.27</option>
+                <option value="3.28 LTS">3.28 LTS</option>
                 <option value="4.x">4.x</option>
                 <option value="None">None</option>
                 <option value="I don't know">I don't know</option>
@@ -347,36 +354,65 @@
                     <label for="wcev-2-x">2.x</label>
                   </li>
                   <li>
-                    <input type="checkbox" id="wcev-3-0-3-4" name="work-company-apps-ember-versions-used-3-0-3-4" />
-                    <label for="wcev-3-0-3-4">3.0 - 3.4</label>
+                    <input type="checkbox" id="wcev-3-0-3-3" name="work-company-apps-ember-versions-used-3-0-3-3" />
+                    <label for="wcev-3-0-3-3">3.0 - 3.3</label>
                   </li>
                   <li>
-                    <input type="checkbox" id="wcev-3-5-3-8" name="work-company-apps-ember-versions-used-3-5-3-8" />
-                    <label for="wcev-3-5-3-8">3.5 - 3.8</label>
+                    <input type="checkbox" id="wcev-3-4-lts" name="work-company-apps-ember-versions-used-3-4-lts" />
+                    <label for="wcev-3-4-lts">3.4 LTS</label>
                   </li>
                   <li>
-                    <input type="checkbox" id="wcev-3-9-3-12" name="work-company-apps-ember-versions-used-3-9-3-12" />
-                    <label for="wcev-3-9-3-12">3.9 - 3.12</label>
+                  <li>
+                    <input type="checkbox" id="wcev-3-5-3-7" name="work-company-apps-ember-versions-used-3-5-3-7" />
+                    <label for="wcev-3-5-3-7">3.5 - 3.7</label>
                   </li>
                   <li>
-                    <input type="checkbox" id="wcev-3-13-3-16" name="work-company-apps-ember-versions-used-3-13-3-16" />
-                    <label for="wcev-3-13-3-16">3.13 - 3.16</label>
+                    <input type="checkbox" id="wcev-3-8-lts" name="work-company-apps-ember-versions-used-3-8-lts" />
+                    <label for="wcev-3-8-lts">3.8 LTS</label>
                   </li>
                   <li>
-                    <input type="checkbox" id="wcev-3-17-3-20" name="work-company-apps-ember-versions-used-3-17-3-20" />
-                    <label for="wcev-3-17-3-20">3.17 - 3.20</label>
+                    <input type="checkbox" id="wcev-3-9-3-11" name="work-company-apps-ember-versions-used-3-9-3-11" />
+                    <label for="wcev-3-9-3-11">3.9 - 3.11</label>
                   </li>
                   <li>
-                    <input type="checkbox" id="wcev-3-21-3-24" name="work-company-apps-ember-versions-used-3-21-3-24" />
-                    <label for="wcev-3-21-3-24">3.21 - 3.24</label>
+                    <input type="checkbox" id="wcev-3-12-lts" name="work-company-apps-ember-versions-used-3-12-lts" />
+                    <label for="wcev-3-12-lts">3.12 LTS</label>
                   </li>
                   <li>
-                    <input type="checkbox" id="wcev325328" name="work-company-apps-ember-versions-used-3-25-3-28" />
-                    <label for="wcev325328">3.25 - 3.28</label>
+                    <input type="checkbox" id="wcev-3-13-3-15" name="work-company-apps-ember-versions-used-3-13-3-15" />
+                    <label for="wcev-3-13-3-15">3.13 - 3.15</label>
                   </li>
                   <li>
-                    <input type="checkbox" id="wcev4x" name="work-company-apps-ember-versions-used-4-x" />
-                    <label for="wcev4x">4.x</label>
+                    <input type="checkbox" id="wcev-3-16-lts" name="work-company-apps-ember-versions-used-3-16-lts" />
+                    <label for="wcev-3-16-lts">3.16 LTS</label>
+                  </li>
+                  <li>
+                    <input type="checkbox" id="wcev-3-17-3-19" name="work-company-apps-ember-versions-used-3-17-3-19" />
+                    <label for="wcev-3-17-3-19">3.17 - 3.19</label>
+                  </li>
+                  <li>
+                    <input type="checkbox" id="wcev-3-20-lts" name="work-company-apps-ember-versions-used-3-20-lts" />
+                    <label for="wcev-3-20-lts">3.20 LTS</label>
+                  </li>
+                  <li>
+                    <input type="checkbox" id="wcev-3-21-3-23" name="work-company-apps-ember-versions-used-3-21-3-23" />
+                    <label for="wcev-3-21-3-23">3.21 - 3.23</label>
+                  </li>
+                  <li>
+                    <input type="checkbox" id="wcev-3-24-lts" name="work-company-apps-ember-versions-used-3-24-lts" />
+                    <label for="wcev-3-24-lts">3.24 LTS</label>
+                  </li>
+                  <li>
+                    <input type="checkbox" id="wcev-3-25-3-27" name="work-company-apps-ember-versions-used-3-25-3-27" />
+                    <label for="wcev-3-25-3-27">3.25 - 3.27</label>
+                  </li>
+                  <li>
+                    <input type="checkbox" id="wcev-3-28-lts" name="work-company-apps-ember-versions-used-3-28-lts" />
+                    <label for="wcev-3-28-lts">3.28 LTS</label>
+                  </li>
+                  <li>
+                    <input type="checkbox" id="wcev-4-x" name="work-company-apps-ember-versions-used-4-x" />
+                    <label for="wcev-4-x">4.x</label>
                   </li>
                   <li>
                     <input type="checkbox" id="wcev-idk" name="work-company-apps-ember-versions-used-idk" />

--- a/app/components/section-work.hbs
+++ b/app/components/section-work.hbs
@@ -362,7 +362,6 @@
                     <label for="wcev-3-4-lts">3.4 LTS</label>
                   </li>
                   <li>
-                  <li>
                     <input type="checkbox" id="wcev-3-5-3-7" name="work-company-apps-ember-versions-used-3-5-3-7" />
                     <label for="wcev-3-5-3-7">3.5 - 3.7</label>
                   </li>


### PR DESCRIPTION
If merged, this PR will update the options available for selection when asking about Ember versions. 

Specifically, it:
- Removes LTS versions from the 'ranged' selection options
- Adds each LTS version as its own, named selectable option

Example:

```diff
- 3.0 - 3.4
+ 3.0 - 3.3
+ 3.4 LTS
```